### PR TITLE
Support Inpsyde Assets 2.5+ & Composer 2

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -14,7 +14,7 @@ jobs:
           uses: shivammathur/setup-php@v2
           with:
             php-version: ${{ matrix.php-versions }}
-            tools: composer:v1
+            tools: composer:v2
 
       -   name: Check syntax error in sources
           run: find ./src/ ./tests/ -type f -name '*.php' -print0 | xargs -0 -L 1 -P 4 -- php -l

--- a/.github/workflows/pre-compile-assets.yml
+++ b/.github/workflows/pre-compile-assets.yml
@@ -21,7 +21,7 @@ jobs:
           uses: shivammathur/setup-php@v2
           with:
             php-version: 7.3
-            tools: composer:v1
+            tools: composer:v2
 
       -   name: "Install dependencies"
           run: composer install --no-interaction --prefer-dist --classmap-authoritative

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ report-*.txt
 # Generated files
 /svn-assets
 /*.zip
+
+# Composer Assets Compiler
+.composer_compiled_assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 2.0.0
+## 1.4.0
 
 ### Updated
 - Updated `inpsyde/assets` to version `~2.5`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG
 
+## 2.0.0
+
+### Updated
+- Updated `inpsyde/assets` to version `~2.5`
+- Updated `inpsyde/php-coding-standards` to version `1.0.0-RC1`.
+- Update most of the codebase to follow the updated standards
+- Update dependencies to support composer 2
+
+
+## 1.3.1
+
+### Updated
+- change psr/container to ~1.0 because of https://github.com/php-fig/container/pull/27
+
+## 1.3
+
+### Updated
+- Updated `inpsyde/assets` to version `~2.1`
 
 ## 1.2
 

--- a/README.md
+++ b/README.md
@@ -19,22 +19,22 @@ Documentation can be found in [readme.txt](readme.txt).
 * WordPress >= 4.6.
 * PHP 7 or higher.
 
-## How to start develop
+## How to start development
 
 This plugin does not include build assets and PHP-dependencies. Therefore, after loading that repository via Composer or git checkout you have to install them.
 
 **With Yarn:**
 
-```js
-yarn install && yarn run develop
+```shell
+yarn install && yarn encore dev
 ```
 
 **With NPM:**
-```js
-npm install && npm run develop
+```shell
+npm install && npm run dev
 ```
 
-The `develop`-script generates all JavaScript- and CSS-files and also runs `composer install` to create the autoloading.
+For more information, please refer to the [Symfony Encore docs](https://symfony.com/doc/current/frontend.html#webpack-encore)
 
 ## Testing & Quality
 To run all tests you've to install composer dev-dependencies first.

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "inpsyde/assets": "~2.5"
     },
     "require-dev": {
-        "php": ">=7",
+        "php": ">=7.1",
         "phpunit/phpunit": "6.3.*",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "inpsyde/php-coding-standards": "1.0.0-RC.1",

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,13 @@
         "psr/container": "~1.0",
         "brain/nonces": "1.0.*",
         "chrico/wp-fields": "~1.0",
-        "inpsyde/assets": "~2.1"
+        "inpsyde/assets": "~2.5"
     },
     "require-dev": {
         "php": ">=7",
         "phpunit/phpunit": "6.3.*",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
-        "inpsyde/php-coding-standards": "^0.12",
-        "squizlabs/php_codesniffer": "~3.2.3",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+        "inpsyde/php-coding-standards": "1.0.0-RC.1",
         "brain/monkey": "^2",
         "inpsyde/composer-assets-compiler": "v2.x-dev"
     },

--- a/src/App/BootableProvider.php
+++ b/src/App/BootableProvider.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\App;
 

--- a/src/App/ConfigBuilder.php
+++ b/src/App/ConfigBuilder.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\App;
 
@@ -40,7 +44,7 @@ final class ConfigBuilder
                 'assets.suffix' => $config->get('debug.mode')
                     ? ''
                     : '.min',
-                'assets.url' => $config->get('plugin.url').'assets/',
+                'assets.url' => $config->get('plugin.url') . 'assets/',
             ]
         );
 
@@ -57,7 +61,7 @@ final class ConfigBuilder
     private static function generatePluginHeaders(string $file): array
     {
         if (defined('ABSPATH')) {
-            $pluginsFile = ABSPATH.'/wp-admin/includes/plugin.php';
+            $pluginsFile = ABSPATH . '/wp-admin/includes/plugin.php';
             if (! function_exists('get_config') && file_exists($pluginsFile)) {
                 require_once($pluginsFile);
             }

--- a/src/App/PluginConfig.php
+++ b/src/App/PluginConfig.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\App;
 
@@ -100,7 +104,7 @@ class PluginConfig implements ContainerInterface
         if (! is_array($var) && ! is_object($var)) {
             $this->stop(
                 'Cannot import this variable.
-				Use arrays and objects only, not a "'.gettype($var).'".'
+				Use arrays and objects only, not a "' . gettype($var) . '".'
             );
         }
 

--- a/src/App/Provider.php
+++ b/src/App/Provider.php
@@ -1,4 +1,4 @@
-<?php # -*- coding: utf-8 -*-
+<?php# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\App;
 

--- a/src/App/Provider.php
+++ b/src/App/Provider.php
@@ -1,4 +1,6 @@
-<?php# -*- coding: utf-8 -*-
+<?php
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\App;
 

--- a/src/App/Provider/AssetProvider.php
+++ b/src/App/Provider/AssetProvider.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\App\Provider;
 
@@ -27,17 +31,17 @@ final class AssetProvider implements \Inpsyde\GoogleTagManager\App\Provider
         $config = $plugin->get('config');
         add_action(
             AssetManager::ACTION_SETUP,
-            function (AssetManager $manager) use ($config) {
+            static function (AssetManager $manager) use ($config) {
                 $assetUrl = $config->get('assets.url');
                 $manager->register(
                     (new Script(
                         'inpsyde-google-tag-manager-admin',
-                        $assetUrl.'inpsyde-google-tag-manager-admin.js',
+                        $assetUrl . 'inpsyde-google-tag-manager-admin.js',
                         Asset::BACKEND
                     ))->withDependencies('jquery-ui-tabs'),
                     (new Style(
                         'inpsyde-google-tag-manager-admin',
-                        $assetUrl.'inpsyde-google-tag-manager-admin.css',
+                        $assetUrl . 'inpsyde-google-tag-manager-admin.css',
                         Asset::BACKEND
                     ))
                 );

--- a/src/App/Provider/DataLayerProvider.php
+++ b/src/App/Provider/DataLayerProvider.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\App\Provider;
 
@@ -23,21 +27,21 @@ final class DataLayerProvider implements BootableProvider
     {
         $plugin->set(
             'DataLayer',
-            function (GoogleTagManager $plugin): DataLayer {
+            static function (GoogleTagManager $plugin): DataLayer {
                 return new DataLayer($plugin->get('Settings.SettingsRepository'));
             }
         );
 
         $plugin->set(
             'DataLayer.User.UserDataCollector',
-            function (GoogleTagManager $plugin): UserDataCollector {
+            static function (GoogleTagManager $plugin): UserDataCollector {
                 return new UserDataCollector($plugin->get('Settings.SettingsRepository'));
             }
         );
 
         $plugin->set(
             'DataLayer.Site.SiteInfoDataCollector',
-            function (GoogleTagManager $plugin): SiteInfoDataCollector {
+            static function (GoogleTagManager $plugin): SiteInfoDataCollector {
                 return new SiteInfoDataCollector($plugin->get('Settings.SettingsRepository'));
             }
         );

--- a/src/App/Provider/FormProvider.php
+++ b/src/App/Provider/FormProvider.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\App\Provider;
 
@@ -20,7 +24,7 @@ final class FormProvider implements \Inpsyde\GoogleTagManager\App\Provider
     {
         $plugin->set(
             'ChriCo.Fields.ElementFactory',
-            function (): ElementFactory {
+            static function (): ElementFactory {
                 return new ElementFactory();
             }
         );

--- a/src/App/Provider/RendererProvider.php
+++ b/src/App/Provider/RendererProvider.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\App\Provider;
 
@@ -27,21 +31,21 @@ final class RendererProvider implements BootableProvider
     {
         $plugin->set(
             'Renderer.GtmScriptTagRenderer',
-            function (GoogleTagManager $plugin): GtmScriptTagRenderer {
+            static function (GoogleTagManager $plugin): GtmScriptTagRenderer {
                 return new GtmScriptTagRenderer($plugin->get('DataLayer'));
             }
         );
 
         $plugin->set(
             'Renderer.DataLayerRenderer',
-            function (GoogleTagManager $plugin): DataLayerRenderer {
+            static function (GoogleTagManager $plugin): DataLayerRenderer {
                 return new DataLayerRenderer($plugin->get('DataLayer'));
             }
         );
 
         $plugin->set(
             'Renderer.NoscriptTagRenderer',
-            function (GoogleTagManager $plugin): NoscriptTagRenderer {
+            static function (GoogleTagManager $plugin): NoscriptTagRenderer {
                 return new NoscriptTagRenderer($plugin->get('DataLayer'));
             }
         );

--- a/src/App/Provider/SettingsProvider.php
+++ b/src/App/Provider/SettingsProvider.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\App\Provider;
 
@@ -23,14 +27,14 @@ final class SettingsProvider implements BootableProvider
     {
         $plugin->set(
             'Settings.SettingsRepository',
-            function (GoogleTagManager $plugin): SettingsRepository {
+            static function (GoogleTagManager $plugin): SettingsRepository {
                 return new SettingsRepository($plugin->get('config')->get('plugin.textdomain'));
             }
         );
 
         $plugin->set(
             'Settings.Page',
-            function (GoogleTagManager $plugin): SettingsPage {
+            static function (GoogleTagManager $plugin): SettingsPage {
                 return new SettingsPage(
                     new TabbedSettingsPageView($plugin->get('config')),
                     $plugin->get('Settings.SettingsRepository')

--- a/src/DataLayer/DataCollectorInterface.php
+++ b/src/DataLayer/DataCollectorInterface.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\DataLayer;
 

--- a/src/DataLayer/DataCollectorInterface.php
+++ b/src/DataLayer/DataCollectorInterface.php
@@ -12,8 +12,8 @@ namespace Inpsyde\GoogleTagManager\DataLayer;
 interface DataCollectorInterface
 {
 
-    const VALUE_ENABLED = 'enabled';
-    const VALUE_DISABLED = 'disabled';
+    public const VALUE_ENABLED = 'enabled';
+    public const VALUE_DISABLED = 'disabled';
 
     /**
      * Checks if for the current page this is usable.

--- a/src/DataLayer/DataLayer.php
+++ b/src/DataLayer/DataLayer.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\DataLayer;
 
@@ -88,7 +92,7 @@ class DataLayer implements SettingsSpecAwareInterface
     {
         return array_filter(
             $this->data,
-            function (DataCollectorInterface $data): bool {
+            static function (DataCollectorInterface $data): bool {
                 return $data->isAllowed();
             }
         );
@@ -128,7 +132,7 @@ class DataLayer implements SettingsSpecAwareInterface
                 'inpsyde-google-tag-manager'
             ),
             '<code>&lt;body&gt;</code>',
-            '<pre><code>&lt;?php do_action( "'.NoscriptTagRendererEvent::ACTION_RENDER.'" ); ?&gt;</code></pre>'
+            '<pre><code>&lt;?php do_action( "' . NoscriptTagRendererEvent::ACTION_RENDER . '" ); ?&gt;</code></pre>'
         );
         // phpcs:enable
 

--- a/src/DataLayer/DataLayer.php
+++ b/src/DataLayer/DataLayer.php
@@ -20,11 +20,11 @@ use Inpsyde\Validator\RegEx;
 class DataLayer implements SettingsSpecAwareInterface
 {
 
-    const DATALAYER_NAME = 'dataLayer';
-    const SETTING__KEY = 'dataLayer';
-    const SETTING__GTM_ID = 'gtm_id';
-    const SETTING__AUTO_INSERT_NOSCRIPT = 'auto_insert_noscript';
-    const SETTING__DATALAYER_NAME = 'datalayer_name';
+    public const DATALAYER_NAME = 'dataLayer';
+    public const SETTING__KEY = 'dataLayer';
+    public const SETTING__GTM_ID = 'gtm_id';
+    public const SETTING__AUTO_INSERT_NOSCRIPT = 'auto_insert_noscript';
+    public const SETTING__DATALAYER_NAME = 'datalayer_name';
 
     /**
      * @var DataCollectorInterface[]
@@ -134,7 +134,6 @@ class DataLayer implements SettingsSpecAwareInterface
             '<code>&lt;body&gt;</code>',
             '<pre><code>&lt;?php do_action( "' . NoscriptTagRendererEvent::ACTION_RENDER . '" ); ?&gt;</code></pre>'
         );
-        // phpcs:enable
 
         $noscript = [
             'label' => __('Auto insert noscript in body', 'inpsyde-google-tag-manager'),

--- a/src/DataLayer/Site/SiteInfoDataCollector.php
+++ b/src/DataLayer/Site/SiteInfoDataCollector.php
@@ -16,10 +16,10 @@ use Inpsyde\GoogleTagManager\Settings\SettingsSpecAwareInterface;
 class SiteInfoDataCollector implements DataCollectorInterface, SettingsSpecAwareInterface
 {
 
-    const SETTING__KEY = 'siteInfo';
-    const SETTING__ENABLED = 'enabled';
-    const SETTING__MULTISITE_FIELDS = 'multisite_fields';
-    const SETTING__BLOG_INFO = 'blog_info';
+    public const SETTING__KEY = 'siteInfo';
+    public const SETTING__ENABLED = 'enabled';
+    public const SETTING__MULTISITE_FIELDS = 'multisite_fields';
+    public const SETTING__BLOG_INFO = 'blog_info';
 
     /**
      * @var array
@@ -98,6 +98,7 @@ class SiteInfoDataCollector implements DataCollectorInterface, SettingsSpecAware
      * @return array
      */
     // phpcs:disable Inpsyde.CodeQuality.FunctionLength.TooLong
+    // phpcs:disable Inpsyde.CodeQuality.LineLength.TooLong
     public function settingsSpec(): array
     {
         $enabled = [

--- a/src/DataLayer/Site/SiteInfoDataCollector.php
+++ b/src/DataLayer/Site/SiteInfoDataCollector.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\DataLayer\Site;
 

--- a/src/DataLayer/User/UserDataCollector.php
+++ b/src/DataLayer/User/UserDataCollector.php
@@ -16,10 +16,10 @@ use Inpsyde\GoogleTagManager\Settings\SettingsSpecAwareInterface;
 class UserDataCollector implements DataCollectorInterface, SettingsSpecAwareInterface
 {
 
-    const SETTING__KEY = 'userData';
-    const SETTING__ENABLED = 'enabled';
-    const SETTING__VISITOR_ROLE = 'visitor_role';
-    const SETTING__FIELDS = 'fields';
+    public const SETTING__KEY = 'userData';
+    public const SETTING__ENABLED = 'enabled';
+    public const SETTING__VISITOR_ROLE = 'visitor_role';
+    public const SETTING__FIELDS = 'fields';
 
     /**
      * @var array
@@ -122,6 +122,7 @@ class UserDataCollector implements DataCollectorInterface, SettingsSpecAwareInte
      * @return array
      */
     // phpcs:disable Inpsyde.CodeQuality.FunctionLength.TooLong
+    // phpcs:disable Inpsyde.CodeQuality.LineLength.TooLong
     public function settingsSpec(): array
     {
         $enabled = [

--- a/src/DataLayer/User/UserDataCollector.php
+++ b/src/DataLayer/User/UserDataCollector.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\DataLayer\User;
 

--- a/src/Event/BootstrapEvent.php
+++ b/src/Event/BootstrapEvent.php
@@ -12,5 +12,5 @@ namespace Inpsyde\GoogleTagManager\Event;
 class BootstrapEvent
 {
 
-    const ACTION = 'inpsyde-google-tag-manager.boot';
+    public const ACTION = 'inpsyde-google-tag-manager.boot';
 }

--- a/src/Event/BootstrapEvent.php
+++ b/src/Event/BootstrapEvent.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Event;
 

--- a/src/Event/GtmScriptTagRendererEvent.php
+++ b/src/Event/GtmScriptTagRendererEvent.php
@@ -12,6 +12,6 @@ namespace Inpsyde\GoogleTagManager\Event;
 final class GtmScriptTagRendererEvent
 {
 
-    const ACTION_AFTER_SCRIPT = 'inpsyde-google-tag-manager.after-script';
-    const ACTION_BEFORE_SCRIPT = 'inpsyde-google-tag-manager.before-script';
+    public const ACTION_AFTER_SCRIPT = 'inpsyde-google-tag-manager.after-script';
+    public const ACTION_BEFORE_SCRIPT = 'inpsyde-google-tag-manager.before-script';
 }

--- a/src/Event/GtmScriptTagRendererEvent.php
+++ b/src/Event/GtmScriptTagRendererEvent.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Event;
 

--- a/src/Event/LogEvent.php
+++ b/src/Event/LogEvent.php
@@ -12,5 +12,5 @@ namespace Inpsyde\GoogleTagManager\Event;
 final class LogEvent
 {
 
-    const ACTION = 'inpsyde-google-tag-manager.log';
+    public const ACTION = 'inpsyde-google-tag-manager.log';
 }

--- a/src/Event/LogEvent.php
+++ b/src/Event/LogEvent.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Event;
 

--- a/src/Event/NoscriptTagRendererEvent.php
+++ b/src/Event/NoscriptTagRendererEvent.php
@@ -12,5 +12,5 @@ namespace Inpsyde\GoogleTagManager\Event;
 final class NoscriptTagRendererEvent
 {
 
-    const ACTION_RENDER = 'inpsyde-google-tag-manager.render-noscript';
+    public const ACTION_RENDER = 'inpsyde-google-tag-manager.render-noscript';
 }

--- a/src/Event/NoscriptTagRendererEvent.php
+++ b/src/Event/NoscriptTagRendererEvent.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Event;
 

--- a/src/Exception/AlreadyBootedException.php
+++ b/src/Exception/AlreadyBootedException.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Exception;
 

--- a/src/Exception/ConfigAlreadyFrozenException.php
+++ b/src/Exception/ConfigAlreadyFrozenException.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Exception;
 

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Exception;
 

--- a/src/GoogleTagManager.php
+++ b/src/GoogleTagManager.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager;
 
@@ -109,7 +113,8 @@ final class GoogleTagManager implements ContainerInterface
             );
         }
 
-        if (! \is_object($this->values[$id])
+        if (
+            ! \is_object($this->values[$id])
             || ! \method_exists($this->values[$id], '__invoke')
         ) {
             return $this->values[$id];

--- a/src/Http/ParameterBag.php
+++ b/src/Http/ParameterBag.php
@@ -123,7 +123,7 @@ class ParameterBag implements Countable, IteratorAggregate
      *
      * @link  http://php.net/manual/en/iteratoraggregate.getiterator.php
      *
-     * @return Traversable An instance of an object implementing <b>Iterator</b> or <b>Traversable</b>,
+     * @return Traversable Instance of an object implementing <b>Iterator</b> or <b>Traversable</b>
      */
     public function getIterator(): Traversable
     {

--- a/src/Http/ParameterBag.php
+++ b/src/Http/ParameterBag.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Http;
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Http;
 

--- a/src/Renderer/DataLayerRenderer.php
+++ b/src/Renderer/DataLayerRenderer.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Renderer;
 
@@ -38,7 +42,7 @@ class DataLayerRenderer
 
         $dataLayerJs = array_reduce(
             $data,
-            function (string $script, DataCollectorInterface $data) use ($dataLayerName): string {
+            static function (string $script, DataCollectorInterface $data) use ($dataLayerName): string {
                 $script .= "\n";
                 $script .= sprintf('%1$s.push(%2$s);', esc_js($dataLayerName), wp_json_encode($data->data()));
 

--- a/src/Renderer/DataLayerRenderer.php
+++ b/src/Renderer/DataLayerRenderer.php
@@ -35,6 +35,7 @@ class DataLayerRenderer
      *
      * @return bool
      */
+    // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
     public function render(): bool
     {
         $data = $this->dataLayer->data();
@@ -44,7 +45,11 @@ class DataLayerRenderer
             $data,
             static function (string $script, DataCollectorInterface $data) use ($dataLayerName): string {
                 $script .= "\n";
-                $script .= sprintf('%1$s.push(%2$s);', esc_js($dataLayerName), wp_json_encode($data->data()));
+                $script .= sprintf(
+                    '%1$s.push(%2$s);',
+                    esc_js($dataLayerName),
+                    wp_json_encode($data->data())
+                );
 
                 return $script;
             },
@@ -54,11 +59,12 @@ class DataLayerRenderer
         <script>
             <?php
             printf('var %1$s = %1$s || [];', esc_js($dataLayerName));
-            echo $dataLayerJs; /* xss ok */
+            echo $dataLayerJs;
             ?>
         </script>
         <?php
 
         return true;
     }
+    // phpcs:enable
 }

--- a/src/Renderer/GtmScriptTagRenderer.php
+++ b/src/Renderer/GtmScriptTagRenderer.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Renderer;
 

--- a/src/Renderer/NoscriptTagRenderer.php
+++ b/src/Renderer/NoscriptTagRenderer.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Renderer;
 
@@ -73,7 +77,7 @@ class NoscriptTagRenderer
         // adding the data to the iframe src as query param.
         $url = array_reduce(
             $this->dataLayer->data(),
-            function (string $url, DataCollectorInterface $data): string {
+            static function (string $url, DataCollectorInterface $data): string {
                 return add_query_arg($data->data(), $url);
             },
             $url
@@ -84,7 +88,7 @@ class NoscriptTagRenderer
             $url
         );
 
-        return '<noscript>'.$iframe.'</noscript>';
+        return '<noscript>' . $iframe . '</noscript>';
     }
 
     /**
@@ -107,7 +111,7 @@ class NoscriptTagRenderer
             return $classes;
         }
 
-        $classes[] = '">'.$html.'<br style="display:none;';
+        $classes[] = '">' . $html . '<br style="display:none;';
 
         return $classes;
     }

--- a/src/Renderer/NoscriptTagRenderer.php
+++ b/src/Renderer/NoscriptTagRenderer.php
@@ -16,7 +16,7 @@ use Inpsyde\GoogleTagManager\Event\LogEvent;
 class NoscriptTagRenderer
 {
 
-    const GTM_URL = 'https://www.googletagmanager.com/ns.html';
+    public const GTM_URL = 'https://www.googletagmanager.com/ns.html';
 
     /**
      * @var DataLayer
@@ -38,10 +38,12 @@ class NoscriptTagRenderer
      *
      * @wp-hook inpsyde-google-tag-manager.noscript
      */
+    // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
     public function render()
     {
-        echo $this->noscript(); /* xss ok */
+        echo $this->noscript();
     }
+    // phpcs:enable
 
     /**
      * Returns the <noscript>-tag for GTM.
@@ -84,8 +86,9 @@ class NoscriptTagRenderer
         );
 
         $iframe = sprintf(
-            '<iframe src="%s" height="0" width="0" style="display:none;visibility:hidden"></iframe>',
-            $url
+            '<iframe src="%s" height="0" width="0" style="%s"></iframe>',
+            $url,
+            'display:none;visibility:hidden'
         );
 
         return '<noscript>' . $iframe . '</noscript>';

--- a/src/Settings/Auth/SettingsPageAuth.php
+++ b/src/Settings/Auth/SettingsPageAuth.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Settings\Auth;
 

--- a/src/Settings/Auth/SettingsPageAuth.php
+++ b/src/Settings/Auth/SettingsPageAuth.php
@@ -17,7 +17,7 @@ use Inpsyde\GoogleTagManager\Event\LogEvent;
 class SettingsPageAuth implements SettingsPageAuthInterface
 {
 
-    const DEFAULT_CAP = 'manage_options';
+    public const DEFAULT_CAP = 'manage_options';
 
     /**
      * @var string

--- a/src/Settings/Auth/SettingsPageAuthInterface.php
+++ b/src/Settings/Auth/SettingsPageAuthInterface.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Settings\Auth;
 

--- a/src/Settings/SettingsPage.php
+++ b/src/Settings/SettingsPage.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Settings;
 
@@ -89,7 +93,7 @@ class SettingsPage
             }
         );
 
-        add_action('load-'.$hook, [$this, 'update']);
+        add_action('load-' . $hook, [$this, 'update']);
 
         return true;
     }
@@ -137,7 +141,8 @@ class SettingsPage
         $data = [];
         foreach ($this->form->elements() as $name => $element) {
             /** @var ElementInterface|ErrorAwareInterface $element */
-            if ($element instanceof ErrorAwareInterface
+            if (
+                $element instanceof ErrorAwareInterface
                 && $element->hasErrors()
                 && isset($storedData[$name])
             ) {

--- a/src/Settings/SettingsRepository.php
+++ b/src/Settings/SettingsRepository.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Settings;
 

--- a/src/Settings/SettingsSpecAwareInterface.php
+++ b/src/Settings/SettingsSpecAwareInterface.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Settings;
 

--- a/src/Settings/View/SettingsPageViewInterface.php
+++ b/src/Settings/View/SettingsPageViewInterface.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Settings\View;
 

--- a/src/Settings/View/TabbedSettingsPageView.php
+++ b/src/Settings/View/TabbedSettingsPageView.php
@@ -50,6 +50,8 @@ class TabbedSettingsPageView implements SettingsPageViewInterface
      *
      * @throws NotFoundException
      */
+    // phpcs:disable Inpsyde.CodeQuality.LineLength.TooLong
+    // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
     public function render(FormInterface $form, NonceInterface $nonce)
     {
         $url = add_query_arg(
@@ -70,11 +72,11 @@ class TabbedSettingsPageView implements SettingsPageViewInterface
             <form method="post" action="<?= esc_url($url) ?>" class="inpsyde-form" id="inpsyde-form">
                 <div id="inpsyde-tabs" class="inpsyde-tabs">
                     <ul class="inpsyde-tab__navigation wp-clearfix">
-                        <?= array_reduce($sections, [$this, 'renderTabNavItem'], '') /* xss ok */ ?>
+                        <?= array_reduce($sections, [$this, 'renderTabNavItem'], '') ?>
                     </ul>
-                    <?php array_walk($sections, [$this, 'renderTabContent']) /* xss ok */ ?>
+                    <?php array_walk($sections, [$this, 'renderTabContent'])?>
                     <p class="submit clear">
-                        <?= \Brain\Nonces\formField($nonce) /* xss ok */ ?>
+                        <?= \Brain\Nonces\formField($nonce)?>
                         <input type="submit"
                             name="submit"
                             id="submit"
@@ -95,6 +97,7 @@ class TabbedSettingsPageView implements SettingsPageViewInterface
         </div>
         <?php
     }
+    // phpcs:enable
 
     /**
      * @return string
@@ -203,6 +206,7 @@ class TabbedSettingsPageView implements SettingsPageViewInterface
      *
      * @param array $section
      */
+    // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
     public function renderTabContent(array $section)
     {
         if (count($section['elements']) < 1) {
@@ -214,13 +218,14 @@ class TabbedSettingsPageView implements SettingsPageViewInterface
             <h3 class="screen-reader-text"><?= esc_html($section['title']) ?></h3>
             <?php
             if (isset($section['description'])) {
-                echo '<p>' . $section['description'] . '</p>'; /* xss ok */
+                echo '<p>' . $section['description'] . '</p>';
             } ?>
-            <?= array_reduce($section['elements'], [$this, 'renderElement'], ''); /* xss ok */ ?>
+            <?= array_reduce($section['elements'], [$this, 'renderElement'], ''); ?>
         </div>
 
         <?php
     }
+    // phpcs:enable
 
     /**
      * Internal function to render a single element row.

--- a/src/Settings/View/TabbedSettingsPageView.php
+++ b/src/Settings/View/TabbedSettingsPageView.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+# -*- coding: utf-8 -*-
 
 namespace Inpsyde\GoogleTagManager\Settings\View;
 
@@ -79,8 +83,8 @@ class TabbedSettingsPageView implements SettingsPageViewInterface
                         />
                     </p>
                     <img
-                        src="<?= esc_url($this->config->get('assets.url').'images/inpsyde.png'); ?>"
-                        srcset="<?= esc_url($this->config->get('assets.url').'images/inpsyde.svg'); ?>"
+                        src="<?= esc_url($this->config->get('assets.url') . 'images/inpsyde.png'); ?>"
+                        srcset="<?= esc_url($this->config->get('assets.url') . 'images/inpsyde.svg'); ?>"
                         alt="Inpsyde GmbH"
                         width="150"
                         height="47"
@@ -187,7 +191,7 @@ class TabbedSettingsPageView implements SettingsPageViewInterface
     {
         $html .= sprintf(
             '<li class="inpsyde-tab__navigation-item"><a href="#%1$s">%2$s</a></li>',
-            esc_attr('tab--'.$section['id']),
+            esc_attr('tab--' . $section['id']),
             esc_html($section['title'])
         );
 
@@ -210,7 +214,7 @@ class TabbedSettingsPageView implements SettingsPageViewInterface
             <h3 class="screen-reader-text"><?= esc_html($section['title']) ?></h3>
             <?php
             if (isset($section['description'])) {
-                echo '<p>'.$section['description'].'</p>'; /* xss ok */
+                echo '<p>' . $section['description'] . '</p>'; /* xss ok */
             } ?>
             <?= array_reduce($section['elements'], [$this, 'renderElement'], ''); /* xss ok */ ?>
         </div>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Updates package constraints so the current release of Inpsyde Assets is used
Updates package constraints so installation no longer fails with Composer 2
Tiny enhancements to the README to reflect the recent switch to Encore for asset building



* **What is the current behavior?** (You can also link to an open issue here)
Installation currently fails with packages requiring `inpsyde/assets:^2.5`
It also fails with composer 2



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
I don't expect PHP-side problems with the Inpsyde Assets update, but the introduction of composer 2 could mean that future releases are no longer installable using old composer environments

