### PR TITLE
Remove closing bracket in inlineScript method

### DIFF
--- a/src/Renderer/GtmScriptTagRenderer.php
+++ b/src/Renderer/GtmScriptTagRenderer.php
@@ -112,7 +112,7 @@ class GtmScriptTagRenderer
 					j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
 					f.parentNode.insertBefore( j, f );
 				}
-        )( window, document, 'script', '<?= esc_js($dataLayerName); ?>', '<?= esc_js($gtmId); ?>>' );
+        )( window, document, 'script', '<?= esc_js($dataLayerName); ?>', '<?= esc_js($gtmId); ?>' );
         <?php
 
         return ob_get_clean();


### PR DESCRIPTION
Removes a typo, which caused a '>' to be printed after the GTM ID in the output of the inlineScript function in the GtmScriptTagRenderer class.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
#11 


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
