### PR TITLE
IFRAME with invalid URL googletagmanager in SRC attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,5 +52,11 @@
     },
     "suggest": {
         "inpsyde/wonolog": "You may want to install Wonolog to enable logging for this package."
+    },
+    "config": {
+        "allow-plugins": {
+            "inpsyde/composer-assets-compiler": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/src/Renderer/NoscriptTagRenderer.php
+++ b/src/Renderer/NoscriptTagRenderer.php
@@ -97,7 +97,7 @@ class NoscriptTagRenderer
 
         $iframe = sprintf(
             '<iframe src="%s" height="0" width="0" style="%s"></iframe>',
-            esch_url($url),
+            \esc_url($url),
             'display:none;visibility:hidden'
         );
 

--- a/src/Renderer/NoscriptTagRenderer.php
+++ b/src/Renderer/NoscriptTagRenderer.php
@@ -97,7 +97,7 @@ class NoscriptTagRenderer
 
         $iframe = sprintf(
             '<iframe src="%s" height="0" width="0" style="%s"></iframe>',
-            $url,
+            esch_url($url),
             'display:none;visibility:hidden'
         );
 

--- a/tests/phpunit/Unit/Renderer/NoscriptTagRendererTest.php
+++ b/tests/phpunit/Unit/Renderer/NoscriptTagRendererTest.php
@@ -57,6 +57,11 @@ class NoscriptTagRendererTest extends AbstractTestCase
             ->with($expected_data, $first_url)
             ->andReturn($expected_url);
 
+        Functions\expect('esc_url')
+            ->once()
+            ->with($expected_url)
+            ->andReturn($expected_url);
+
         ob_start();
         $testee->render();
         $output = ob_get_clean();
@@ -144,6 +149,7 @@ class NoscriptTagRendererTest extends AbstractTestCase
             ->andReturn([]);
 
         Functions\stubs(['add_query_arg' => '']);
+        Functions\stubs(['esc_url' => '']);
 
         $testee = new NoscriptTagRenderer($dataLayer);
         ob_start();


### PR DESCRIPTION
Jira Ticket No: MDR-218.

Escapes Google tags noscript URL.