### PR TITLE
Fix URL to open Playground instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![codecov](https://codecov.io/gh/inpsyde/google-tag-manager/branch/master/graph/badge.svg)](https://codecov.io/gh/inpsyde/google-tag-manager)
 [![Downloads](https://img.shields.io/packagist/dt/inpsyde/google-tag-manager.svg)](https://packagist.org/packages/inpsyde/google-tag-manager)
 [![License](https://img.shields.io/packagist/l/inpsyde/google-tag-manager.svg)](https://packagist.org/packages/inpsyde/google-tag-manager)
-[![WordPress Playground Demo](https://img.shields.io/badge/Playground_Demo-8A2BE2?logo=wordpress&logoColor=FFFFFF&labelColor=3858E9&color=3858E9)](https://raw.githubusercontent.com/inpsyde/google-tag-manager/refs/heads/master/resources/blueprints/blueprint.json)
+[![WordPress Playground Demo](https://img.shields.io/badge/Playground_Demo-8A2BE2?logo=wordpress&logoColor=FFFFFF&labelColor=3858E9&color=3858E9)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/inpsyde/google-tag-manager/refs/heads/master/resources/blueprints/blueprint.json)
 
 > Inpsyde Google Tag Manager inserts the GTM Container Code on every page of your WordPress site and writes data to the Data Layer.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

**What is the current behavior?** (You can also link to an open issue here)

The button in the README.md file doesn't open a new Playground instance

**What is the new behavior (if this is a feature change)?**

Fix the button

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:

Playground now doesn't work with this version of GTM :upside_down_face: 