### PR TITLE
Fix special characters encoding

### DIFF
--- a/src/Renderer/DataLayerRenderer.php
+++ b/src/Renderer/DataLayerRenderer.php
@@ -47,7 +47,7 @@ class DataLayerRenderer
             $data,
             static function (string $script, DataCollectorInterface $data) use ($dataLayerName): string {
                 $decodedData = array_map(
-                    static function ($item) {
+                    static function (mixed $item): mixed {
                         return is_array($item)
                             ? array_map('html_entity_decode', $item)
                             : html_entity_decode($item);

--- a/src/Renderer/DataLayerRenderer.php
+++ b/src/Renderer/DataLayerRenderer.php
@@ -47,7 +47,8 @@ class DataLayerRenderer
             $data,
             static function (string $script, DataCollectorInterface $data) use ($dataLayerName): string {
                 $decodedData = array_map(
-                    static function (mixed $item): mixed {
+                    // phpcs:ignore
+                    static function ($item) {
                         return is_array($item)
                             ? array_map('html_entity_decode', $item)
                             : html_entity_decode($item);

--- a/src/Renderer/DataLayerRenderer.php
+++ b/src/Renderer/DataLayerRenderer.php
@@ -46,11 +46,20 @@ class DataLayerRenderer
         $dataLayerJs = array_reduce(
             $data,
             static function (string $script, DataCollectorInterface $data) use ($dataLayerName): string {
+                $decodedData = array_map(
+                    static function ($item) {
+                        return is_array($item)
+                            ? array_map('html_entity_decode', $item)
+                            : html_entity_decode($item);
+                    },
+                    $data->data()
+                );
+
                 $script .= "\n";
                 $script .= sprintf(
                     '%1$s.push(%2$s);',
                     esc_js($dataLayerName),
-                    wp_json_encode($data->data())
+                    (string) wp_json_encode($decodedData)
                 );
 
                 return $script;

--- a/tests/phpunit/Unit/Renderer/DataLayerRendererTest.php
+++ b/tests/phpunit/Unit/Renderer/DataLayerRendererTest.php
@@ -25,13 +25,22 @@ class DataLayerRendererTest extends AbstractTestCase
      */
     public function testRender(): void
     {
-        $expected_data = ['foo' => 'bar'];
+        $encoded_data = [
+            'foo' => 'bar',
+            'foo2' => 'Test this &amp; this',
+            'foo3' => 'This is > than this' // let's also test a not encoded case
+        ];
+        $expected_data = [
+            'foo' => 'bar',
+            'foo2' => 'Test this & this',
+            'foo3' => 'This is > than this'
+        ];
         $expected_name = 'baz';
 
         $data = Mockery::mock(DataCollectorInterface::class);
         $data->shouldReceive('data')
             ->once()
-            ->andReturn($expected_data);
+            ->andReturn($encoded_data);
 
         $dataLayer = Mockery::mock(DataLayer::class);
         $dataLayer->shouldReceive('name')


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** 
Bug Fix


**What is the current behavior?**
HTML entities are not decoded before being rendered.


**Does this PR introduce a breaking change?**
No.


**Other information**:
This was the entry in the dataLayer before of the change:
```
{
    "ga4_page_customer_specialty": "accident &amp; emergency medicine",
    "ga4_page_cmsplatform": "wp-vip",
    "ga4_page_cmstheme": "theme",
    "ga4_page_wpid": "1747",
    "ga4_page_language": "en_us",
    "ga4_post_title": "test tag manager"
}
```

This is after the change instead:
```
{
    "ga4_page_customer_specialty": "accident & emergency medicine",
    "ga4_page_cmsplatform": "wp-vip",
    "ga4_page_cmstheme": "theme",
    "ga4_page_wpid": "1747",
    "ga4_page_language": "en_us",
    "ga4_post_title": "test tag manager"
}
```